### PR TITLE
fix(dark-mode): apply dark theme to sidebar and code snippets

### DIFF
--- a/jules-scratch/verification/verify_dark_mode.py
+++ b/jules-scratch/verification/verify_dark_mode.py
@@ -1,0 +1,15 @@
+from playwright.sync_api import Page, expect
+
+def test_dark_mode(page: Page):
+    # Navigate to the app
+    page.goto("http://localhost:3000")
+
+    # Wait for the page to load
+    expect(page.get_by_role("heading", name="React Concepts")).to_be_visible()
+
+    # Switch to dark mode
+    toggler = page.get_by_role("button", name="Switch Theme")
+    toggler.click()
+
+    # Take a screenshot
+    page.screenshot(path="jules-scratch/verification/dark_mode_verification.png")

--- a/react-learning-visualizer/src/layout/Sidebar.js
+++ b/react-learning-visualizer/src/layout/Sidebar.js
@@ -5,10 +5,12 @@ import { concepts } from '../data/concepts';
 
 const SidebarContainer = styled.aside`
   width: 250px;
-  background-color: #f0f0f0;
+  background-color: ${({ theme }) => theme.sidebar.background};
+  color: ${({ theme }) => theme.sidebar.text};
   padding: 20px;
   height: 100%;
   overflow-y: auto;
+  transition: all 0.50s linear;
 `;
 
 const Sidebar = () => {

--- a/react-learning-visualizer/src/pages/ConceptPage.js
+++ b/react-learning-visualizer/src/pages/ConceptPage.js
@@ -14,11 +14,13 @@ const ConceptContainer = styled.div`
     margin-bottom: 20px;
   }
   .code-block {
-    background-color: #f0f0f0;
+    background-color: ${({ theme }) => theme.sidebar.background};
+    color: ${({ theme }) => theme.sidebar.text};
     padding: 20px;
     border-radius: 5px;
     white-space: pre-wrap;
     word-wrap: break-word;
+    transition: all 0.50s linear;
   }
 `;
 

--- a/react-learning-visualizer/src/styles/ThemeProvider.js
+++ b/react-learning-visualizer/src/styles/ThemeProvider.js
@@ -10,13 +10,21 @@ const lightTheme = {
   text: '#363537',
   toggleBorder: '#FFF',
   background: '#363537',
+  sidebar: {
+    background: '#f0f0f0',
+    text: '#363537'
+  }
 };
 
 const darkTheme = {
-  body: '#363537',
+  body: '#000000',
   text: '#FAFAFA',
   toggleBorder: '#6B8096',
-  background: '#999',
+  background: '#000000',
+  sidebar: {
+    background: '#000000',
+    text: '#FAFAFA'
+  }
 };
 
 export const ThemeProvider = ({ children }) => {


### PR DESCRIPTION
This commit fixes the dark mode implementation for the sidebar and code snippets.

- The `darkTheme` object in `ThemeProvider.js` was updated to use a black background.
- The `Sidebar` component was updated to use the theme's background and text colors.
- The `ConceptPage` component was updated to use the theme's background and text colors for code snippets.

I was unable to visually verify the changes due to issues with the Playwright environment.